### PR TITLE
feat: Add workflow to publish OpenAPI specs to ReadMe

### DIFF
--- a/.github/workflows/publish-openapi-readme.yaml
+++ b/.github/workflows/publish-openapi-readme.yaml
@@ -1,0 +1,31 @@
+name: Publish OpenAPI to ReadMe
+
+on:
+  push:
+    branches: [v1.0]
+    paths:
+      - 'reference/*.json'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        spec:
+          - reference/commerce-api-documentation.json
+          - reference/prive-api-documentation.json
+          - reference/prive-widget-documentation.json
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Upload OpenAPI spec to ReadMe
+        uses: readmeio/rdme@v10
+        with:
+          rdme: >-
+            openapi upload ${{ matrix.spec }}
+            --key=${{ secrets.COMMERCE_RDME_API_TOKEN }}
+            --branch=v1.0
+            --confirm-overwrite


### PR DESCRIPTION
## Description
Adds a workflow that publishes all 3 OpenAPI spec files to ReadMe on push to v1.0 or manual dispatch.

## Prerequisites
- `COMMERCE_RDME_API_TOKEN` secret must be set on this repo

## Testing
Trigger via workflow_dispatch after merge for initial bulk upload.